### PR TITLE
Add SCM _version.py

### DIFF
--- a/molot/__init__.py
+++ b/molot/__init__.py
@@ -2,11 +2,11 @@ import logging
 
 from .core import envarg, envarg_bool, envarg_int, envargs_file, evaluate, reset, target
 from .extras import shell
-from .package import setup_logging, version
+from .package import get_version, setup_logging
 
 setup_logging(level=logging.INFO, shutdown=logging.CRITICAL)
 
-__version__ = version
+__version__ = get_version()
 __all__ = [
     "target",
     "envarg",

--- a/molot/core.py
+++ b/molot/core.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional, Union
 
 from dotenv import load_dotenv
 
-from .package import version
+from .package import get_version
 from .state import (
     EnvArg,
     State,
@@ -260,7 +260,7 @@ def evaluate():
     Call to evaluate() must be at the very end of your script!
     """
 
-    print(f"→ Running Molot {version}...")
+    print(f"→ Running Molot {get_version()}...")
 
     args = _argument_parser().parse_args(args=_args)
 

--- a/molot/package.py
+++ b/molot/package.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import logging
 import sys
 
@@ -28,16 +27,15 @@ def setup_logging(level: int, shutdown: int = logging.NOTSET, **kwargs):
 
 
 def get_version() -> str:
-    """Retrieve version from package metadata.
+    """Retrieve version from _version.py file.
 
     Returns:
-        str: Package version or "0.0.0-UNKNOWN" when unavailable.
+        str: Package version or "0.0.0" when file missing.
     """
     try:
-        return importlib.metadata.version("molot")
-    except importlib.metadata.PackageNotFoundError:
-        logging.warning("No version found in metadata")
+        from ._version import __version__  # type: ignore
+
+        return __version__
+    except ModuleNotFoundError:
+        logging.warning("No _version.py file")
         return "0.0.0"
-
-
-version = get_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools>=60", "setuptools-scm"]
 
 [tool.setuptools_scm]
+version_file = "molot/_version.py"
 
 [tool.black]
 include = '\.pyi?$'


### PR DESCRIPTION
Build target generates _version.py and there's a `get_version()` wrapper that ignores issues when the file is missing for local development.