### PR TITLE
Fixes to release process

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
       - master
   release:
     types:
-      - created
+      - released
 
 jobs:
   build:
@@ -27,6 +27,8 @@ jobs:
         run: make dependencies
 
       - name: Build
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.release.tag_name }}
         run: make build
 
       - name: Publish a Python distribution to PyPI

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: dependencies
 dependencies:
+	SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 \
 	uv sync --no-install-project --all-extras --frozen
 
 .PHONY: upgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools~=75.3.0", "setuptools-scm~=8.1.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
- Trigger on release released, not created
- Enforce SCM version for master builds to account for dependency weirdnesses
- Partially pin setuptools and setuptools-scm versions